### PR TITLE
Bf11/exibir mensagem em busca ruim

### DIFF
--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -16,7 +16,7 @@ export class HeaderComponent implements OnInit {
   }
 
   logout() {
-    this.cookieService.set('token', '');
+    this.cookieService.deleteAll();
   }
 
   toggleMenu() {

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -62,12 +62,14 @@ export class LoginComponent implements OnInit {
               this.cookieService.set('userFirstName', response.body['first_name']);
               this.cookieService.set('userLastName', response.body['last_name']);
               this.router.navigate(['']);
+              this.logging = false;
           }
       },
       error => {
           console.log(error);
           const statusAuth = error.status;
           this.errorHandler(statusAuth);
+          this.logging = false;
       });
     }
 

--- a/src/app/minhas-pls/minhas-pls.component.html
+++ b/src/app/minhas-pls/minhas-pls.component.html
@@ -104,9 +104,6 @@
           <p>Ano: {{propositionVote[votePosition].proposition['year']}}</p>
           <p>Abstract: {{propositionVote[votePosition].proposition['abstract']}}</p>
           <p>Situação: {{propositionVote[votePosition].proposition['situation']}}</p>
-          <div>Na íntegra:
-            <a href="{{propositionVote['url_full']}}">link íntegra</a><br/>
-          </div>
           <p> Seu voto:
             <ng-container *ngIf="propositionVote[votePosition]['option'] === 'Y'">
               <span class="glyphicon glyphicon-ok"></span> SIM
@@ -118,6 +115,10 @@
               <span class="glyphicon glyphicon-remove"></span> NÃO
             </ng-container><br>
           </p>
+          <!-- TODO, referenciar essa parada aí em baixo direito! -->
+          <div class="text-center">
+            <button class="btn btn-primary" (click)="openProposition(propositionVote[votePosition].proposition['url_full'])">Veja na íntegra</button>
+          </div>
         </div>
         <div class="modal-footer" *ngIf="showEditButtons">
           <div style="text-align: center; margin-bottom: 10px">

--- a/src/app/minhas-pls/minhas-pls.component.html
+++ b/src/app/minhas-pls/minhas-pls.component.html
@@ -135,28 +135,28 @@
       </div>
     </div>
   </div>
-<table style="width:100%" *ngIf="pages > 0">
+<table style="width:100%" *ngIf="pages > 0 && !loading">
   <tr>
     <div class="row">
       <div class="col-sm-12">
         <ul class="nav nav-pills center">
           <td>
-            <button id="beforeBtn1" class="btn" (click)="propositions(1, term)">Inicio</button>
+            <button *ngIf="offset !== 1" class="btn" (click)="propositions(1, term)">Inicio</button>
           </td>
           <td>
-            <button id="beforeBtn2" class="btn" (click)="propositions(offset-1, term)">Ant.</button>
+            <button *ngIf="offset !== 1" class="btn" (click)="propositions(offset-1, term)">Ant.</button>
           </td>
           <td>
-            <input id="pageBtn1" type="text" size="3" class="form-control" #page>
+            <input *ngIf="pages < 2" type="text" size="3" class="form-control" #page>
           </td>
           <td>
-            <button id="pageBtn2" class="btn" (click)="propositions(page.value, term)">Ir</button>
+            <button *ngIf="pages < 2" class="btn" (click)="propositions(page.value, term)">Ir</button>
           </td>
           <td>
-            <button id="afterBtn1" class="btn" (click)="propositions(offset+1, term)">Prox.</button>
+            <button *ngIf="offset < pages" class="btn" (click)="propositions(offset+1, term)">Prox.</button>
           </td>
           <td>
-            <button id="afterBtn2" class="btn" (click)="propositions(pages, term)">Fim</button>
+            <button *ngIf="offset < pages" class="btn" (click)="propositions(pages, term)">Fim</button>
           </td>
         </ul>
         <br>

--- a/src/app/minhas-pls/minhas-pls.component.html
+++ b/src/app/minhas-pls/minhas-pls.component.html
@@ -79,7 +79,8 @@
   <div class="row" *ngIf="propositionVote?.length <= 0">
     <div class="main-card">
       <div class="main-card-content">
-        <p>Você verá aqui as propostas que votar em "Dê sua opnião"</p>
+        <p *ngIf="term === '';else badSearch">Aqui você verá seus votos, você pode votar <a href='propositions'>aqui</a></p>
+        <p *ngIf="term !== ''">Sua busca não retornou resultados :(</p>
       </div>
     </div>
   </div>

--- a/src/app/minhas-pls/minhas-pls.component.html
+++ b/src/app/minhas-pls/minhas-pls.component.html
@@ -79,7 +79,7 @@
   <div class="row" *ngIf="propositionVote?.length <= 0">
     <div class="main-card">
       <div class="main-card-content">
-        <p *ngIf="term === '';else badSearch">Aqui você verá seus votos, você pode votar <a href='propositions'>aqui</a></p>
+        <p *ngIf="term === ''">Aqui você verá seus votos, você pode votar <a href='propositions'>aqui</a></p>
         <p *ngIf="term !== ''">Sua busca não retornou resultados :(</p>
       </div>
     </div>

--- a/src/app/minhas-pls/minhas-pls.component.ts
+++ b/src/app/minhas-pls/minhas-pls.component.ts
@@ -103,6 +103,13 @@ export class MinhasPlsComponent implements OnInit {
       }
 
     });
+  }
 
+  openProposition(proposition_url) {
+    window.open(
+      proposition_url,
+      '_blank',
+      'height=700, width=820, scrollbars=yes, status=yes'
+    );
   }
 }

--- a/src/app/minhas-pls/minhas-pls.component.ts
+++ b/src/app/minhas-pls/minhas-pls.component.ts
@@ -75,34 +75,8 @@ export class MinhasPlsComponent implements OnInit {
       console.log(this.propositionVote);
       this.offset = offset;
       this.pages = Math.ceil(response['body']['count'] / this.itemsPerPage);
-      this.updateButtonsAppearence(this.offset, this.pages);
       this.loading = false;
     });
-  }
-
-  updateButtonsAppearence(offset, limit) {
-    if (offset === 1) {
-      document.getElementById('beforeBtn1').style.display = 'none';
-      document.getElementById('beforeBtn2').style.display = 'none';
-    } else {
-      document.getElementById('beforeBtn1').style.display = 'block';
-      document.getElementById('beforeBtn2').style.display = 'block';
-    }
-    if (offset >= limit) {
-      document.getElementById('afterBtn1').style.display = 'none';
-      document.getElementById('afterBtn2').style.display = 'none';
-    } else {
-      document.getElementById('afterBtn1').style.display = 'block';
-      document.getElementById('afterBtn2').style.display = 'block';
-    }
-    if (this.pages < 2) {
-      document.getElementById('pageBtn1').style.display = 'none';
-      document.getElementById('pageBtn2').style.display = 'none';
-    } else {
-      document.getElementById('pageBtn1').style.display = 'block';
-      document.getElementById('pageBtn2').style.display = 'block';
-    }
-
   }
 
   specifyProposition(position, showButtons) {

--- a/src/app/minhas-pls/minhas-pls.component.ts
+++ b/src/app/minhas-pls/minhas-pls.component.ts
@@ -54,6 +54,10 @@ export class MinhasPlsComponent implements OnInit {
   }
 
   propositions(offset: number, term) {
+    if (offset < 1 || isNaN(Number(offset)) || offset > this.pages) {
+      alert('Número de páginas inválido, favor digitar um número positivo');
+      return;
+    }
     this.term = term.toUpperCase();
     let req: any;
     this.pages = 1;
@@ -84,7 +88,7 @@ export class MinhasPlsComponent implements OnInit {
       document.getElementById('beforeBtn1').style.display = 'block';
       document.getElementById('beforeBtn2').style.display = 'block';
     }
-    if (offset === limit) {
+    if (offset >= limit) {
       document.getElementById('afterBtn1').style.display = 'none';
       document.getElementById('afterBtn2').style.display = 'none';
     } else {

--- a/src/app/user-following/user-following.component.html
+++ b/src/app/user-following/user-following.component.html
@@ -42,7 +42,7 @@
       <p *ngIf="term === ''">Você ainda não segue deputados,
         <a href="/parliamentarians">veja a lista de deputados</a> e escolha os que você quiser seguir
       </p>
-      <p *ngIf="term !== ''">Sua busca não retornou resultados :( Talvez você não siga este detputado, procure-o 
+      <p *ngIf="term !== ''">Sua busca não retornou resultados :( Talvez você não siga este deputado, procure-o 
         <a href="/parliamentarians">aqui</a>.
       </p>
     </div>

--- a/src/app/user-following/user-following.component.html
+++ b/src/app/user-following/user-following.component.html
@@ -48,33 +48,33 @@
     </div>
   </div>
 </div>
-<table style="width:100%" *ngIf="pages > 0">
+<table style="width:100%" *ngIf="pages > 0 && !loading">
   <tr>
     <div class="row">
       <div class="col-sm-12">
         <ul class="nav nav-pills center">
           <td>
-            <button id="beforeBtn1" class="btn" (click)="loadPage(1, term)">Inicio</button>
+            <button *ngIf="offset > 1" class="btn" (click)="loadPage(1, term)">Inicio</button>
           </td>
           <td>
-            <button id="beforeBtn2" class="btn" (click)="loadPage(offset-1, term)">Ant.</button>
+            <button *ngIf="offset > 1" class="btn" (click)="loadPage(offset-1, term)">Ant.</button>
           </td>
           <td>
-            <input id="pageBtn1" type="text" size="3" class="form-control" #page>
+            <input *ngIf="pages > 1" type="text" size="3" class="form-control" #page>
           </td>
           <td>
-            <button id="pageBtn2" class="btn" (click)="loadPage(page.value, term)">Ir</button>
+            <button *ngIf="pages > 1" class="btn" (click)="loadPage(page.value, term)">Ir</button>
           </td>
           <td>
-            <button id="afterBtn1" class="btn" (click)="loadPage(offset+1, term)">Prox.</button>
+            <button *ngIf="offset < pages" class="btn" (click)="loadPage(offset+1, term)">Prox.</button>
           </td>
           <td>
-            <button id="afterBtn2" class="btn" (click)="loadPage(pages, term)">Fim</button>
+            <button *ngIf="offset < pages" class="btn" (click)="loadPage(pages, term)">Fim</button>
           </td>
         </ul>
         <br>
         <br>
-        <p class="p-center">Página: {{offset}}/{{pages}}</p>
+        <p class="p-center" *ngIf="pages > 1">Página: {{offset}}/{{pages}}</p>
         <br>
       </div>
     </div>

--- a/src/app/user-following/user-following.component.html
+++ b/src/app/user-following/user-following.component.html
@@ -39,8 +39,11 @@
 <div class="row" *ngIf="pages == 0">
   <div class="main-card">
     <div class="main-card-content">
-      <p>Você verá aqui os parlamentares seguidos,
-        <a href="/parliamentarians">ver parlamentares</a>
+      <p *ngIf="term === ''">Você ainda não segue deputados,
+        <a href="/parliamentarians">veja a lista de deputados</a> e escolha os que você quiser seguir
+      </p>
+      <p *ngIf="term !== ''">Sua busca não retornou resultados :( Talvez você não siga este detputado, procure-o 
+        <a href="/parliamentarians">aqui</a>.
       </p>
     </div>
   </div>

--- a/src/app/user-following/user-following.component.ts
+++ b/src/app/user-following/user-following.component.ts
@@ -74,37 +74,10 @@ export class UserFollowingComponent implements OnInit {
       this.pages = auxPages;
       console.log(this.pages);
       this.parliamentarians = this.auxParliamentarian;
-      this.updateButtonsAppearence(this.offset, this.pages);
       this.parliamentarians = this.auxParliamentarian;
       this.loading = false;
       // console.log(this.parliamentarians);
       // console.log(this.pages);
     });
   }
-
-  updateButtonsAppearence(offset, limit) {
-    if (offset === 1) {
-      document.getElementById('beforeBtn1').style.display = 'none';
-      document.getElementById('beforeBtn2').style.display = 'none';
-    } else {
-      document.getElementById('beforeBtn1').style.display = 'block';
-      document.getElementById('beforeBtn2').style.display = 'block';
-    }
-    if (offset === limit) {
-      document.getElementById('afterBtn1').style.display = 'none';
-      document.getElementById('afterBtn2').style.display = 'none';
-    } else {
-      document.getElementById('afterBtn1').style.display = 'block';
-      document.getElementById('afterBtn2').style.display = 'block';
-    }
-    if (this.pages < 2) {
-      document.getElementById('pageBtn1').style.display = 'none';
-      document.getElementById('pageBtn2').style.display = 'none';
-    } else {
-      document.getElementById('pageBtn1').style.display = 'block';
-      document.getElementById('pageBtn2').style.display = 'block';
-    }
-
-  }
-
 }

--- a/src/app/user-following/user-following.component.ts
+++ b/src/app/user-following/user-following.component.ts
@@ -71,13 +71,6 @@ export class UserFollowingComponent implements OnInit {
     request.subscribe( response => {
       this.auxParliamentarian = response['body']['results'];
       const auxPages = Math.ceil(response['body']['count'] / this.itemsPerPage);
-      if (auxPages === 0) {
-        alert('A pesquisa não retornou resultados');
-        return;
-      } else if (this.auxParliamentarian.length <= 0) {
-        alert('Número da página inválido, favor digitar entre 1 e ' + this.pages);
-        return;
-      }
       this.pages = auxPages;
       console.log(this.pages);
       this.parliamentarians = this.auxParliamentarian;


### PR DESCRIPTION
<!-- Escolha apenas UMA das opções abaixo -->
# [BF11 - Tratar retorno de objetos inexistentes](https://github.com/fga-gpp-mds/2018.1-VoxPop-WebApp/issues/153)

<!--- Descrição em linguagem natural do que está acontecendo -->
## Comportamento anterior
A aplicação avisa ao usuário que não há votos registrados.

<!--- Descrição em linguagem natural do que deve acontecer -->
## Comportamento esperado
Quando o usuário realiza uma busca que não retorna votos, a aplicação deve exibir uma mensagem relatando isso. O mesmo ocorre com deputados seguidos.

<!-- O que é necesário para que a issue seja finalizada?-->
## Critérios de aceitação
- [x] Criar mensagem que apareça quando o usuário procurar algo que não retorne nenhum voto
- [x] Criar mensagem que apareça quando o usuário procurar algo que não retorne nenhum deputado seguido

### Edições menores adicionais:
- [x] Corrigido bug de bad login com loading infinito
- [x] Paginação não aparece mais durante loading das páginas editadas

resolves #153 